### PR TITLE
update Ledger Rust SDK deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 ledger_device_sdk = "1.29.0"
-ledger-log = { git = "https://github.com/alamgu/ledger-log.git", branch = "y333/rust_sdk_single_crate" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
 
 [features]
 speculos = ["ledger_device_sdk/speculos"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,10 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
 ledger_device_sdk = "1.28.0"
-ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
+ledger-log = { git = "https://github.com/alamgu/ledger-log.git", branch = "y333/rust_sdk_single_crate" }
 
 [features]
 speculos = ["ledger_device_sdk/speculos"]
 
 [patch.crates-io]
 ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
-
-[patch."https://github.com/alamgu/ledger-log"]
-ledger-log = { path = "../../alamgu/ledger-log" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,8 @@ edition = "2018"
 
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
-ledger_device_sdk = "1.28.0"
+ledger_device_sdk = "1.29.0"
 ledger-log = { git = "https://github.com/alamgu/ledger-log.git", branch = "y333/rust_sdk_single_crate" }
 
 [features]
 speculos = ["ledger_device_sdk/speculos"]
-
-[patch.crates-io]
-ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2018"
 
 [dependencies]
 arrayvec = { version = "0.7.1", default-features = false }
-ledger_device_sdk = "1.4.3"
+ledger_device_sdk = "1.28.0"
 ledger-log = { git = "https://github.com/alamgu/ledger-log.git" }
-include_gif = "1.0.1"
 
 [features]
 speculos = ["ledger_device_sdk/speculos"]
+
+[patch.crates-io]
+ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }
+
+[patch."https://github.com/alamgu/ledger-log"]
+ledger-log = { path = "../../alamgu/ledger-log" }

--- a/src/bitmaps.rs
+++ b/src/bitmaps.rs
@@ -1,4 +1,4 @@
-use include_gif::include_gif;
+use ledger_device_sdk::include_gif;
 use ledger_device_sdk::ui::bitmaps::Glyph;
 
 pub const CHECK_GLYPH: Glyph = Glyph::from_include(include_gif!("icons/check.gif"));


### PR DESCRIPTION
This PR updates the Ledger Rust SDK dependencies: sys crate is now available through the sys feature.
PR should be merged when the new `ledger_device_sdk` crate ( version > 1.28) will be published on crates.io.